### PR TITLE
EZP-30021: Inactive UDW tabs have wrong background colour

### DIFF
--- a/Resources/public/scss/modules/universal-discovery/_content.table.header.scss
+++ b/Resources/public/scss/modules/universal-discovery/_content.table.header.scss
@@ -7,7 +7,7 @@
 
     &__list-header {
         padding: calculateRem(8px) calculateRem(16px);
-        font-weight: normal;
+        font-weight: 700;
         font-size: calculateRem(15px);
         line-height: calculateRem(20px);
 

--- a/Resources/public/scss/modules/universal-discovery/_content.table.header.scss
+++ b/Resources/public/scss/modules/universal-discovery/_content.table.header.scss
@@ -2,7 +2,6 @@
     &__list-headers {
         display: flex;
         flex-wrap: nowrap;
-        background-color: $ez-white;
     }
 
     &__list-header {
@@ -10,6 +9,7 @@
         font-weight: 700;
         font-size: calculateRem(15px);
         line-height: calculateRem(20px);
+        background-color: $ez-white;
 
         &--name {
             flex: 1 1 calculateRem(280px);

--- a/Resources/public/scss/modules/universal-discovery/_content.table.header.scss
+++ b/Resources/public/scss/modules/universal-discovery/_content.table.header.scss
@@ -2,6 +2,7 @@
     &__list-headers {
         display: flex;
         flex-wrap: nowrap;
+        background-color: $ez-white;
     }
 
     &__list-header {
@@ -9,7 +10,6 @@
         font-weight: normal;
         font-size: calculateRem(15px);
         line-height: calculateRem(20px);
-        background-color: $ez-white;
 
         &--name {
             flex: 1 1 calculateRem(280px);

--- a/Resources/public/scss/modules/universal-discovery/_tab.nav.item.scss
+++ b/Resources/public/scss/modules/universal-discovery/_tab.nav.item.scss
@@ -8,7 +8,7 @@
     cursor: pointer;
     transition: background 0.3s $ez-admin-transition, color 0.3s $ez-admin-transition;
     color: $ez-color-base-medium;
-    fill: $ez-color-base-medium;
+    fill: currentColor;
     display: flex;
     align-items: center;
 
@@ -23,7 +23,7 @@
     &--selected:focus {
         background: $ez-ground-base-dark;
         color: $ez-black;
-        fill: $ez-black;
+        fill: currentColor;
         font-weight: bold;
     }
 

--- a/Resources/public/scss/modules/universal-discovery/_tab.nav.item.scss
+++ b/Resources/public/scss/modules/universal-discovery/_tab.nav.item.scss
@@ -1,6 +1,6 @@
 .c-tab-nav-item {
-    background: $ez-ground-base-dark;
     border: 0 none;
+    border-radius: calculateRem(8px) calculateRem(8px) 0 0;
     font-size: calculateRem(16px);
     line-height: calculateRem(30px);
     padding: calculateRem(4px) calculateRem(16px);
@@ -13,8 +13,7 @@
 
     &:hover,
     &:focus {
-        background: $ez-ground-base-dark-hover;
-        border-radius: calculateRem(8px) calculateRem(8px) 0 0;
+        background: $ez-ground-base-medium-hover;
         outline: none;
     }
 

--- a/Resources/public/scss/modules/universal-discovery/_tab.nav.item.scss
+++ b/Resources/public/scss/modules/universal-discovery/_tab.nav.item.scss
@@ -1,19 +1,20 @@
 .c-tab-nav-item {
     border: 0 none;
-    border-radius: calculateRem(8px) calculateRem(8px) 0 0;
+    border-radius: calculateRem(4px) calculateRem(4px) 0 0;
     font-size: calculateRem(16px);
     line-height: calculateRem(30px);
     padding: calculateRem(4px) calculateRem(16px);
     outline: none;
     cursor: pointer;
     transition: background 0.3s $ez-admin-transition, color 0.3s $ez-admin-transition;
-    color: $ez-color-base-dark;
+    color: $ez-color-base-medium;
+    fill: $ez-color-base-medium;
     display: flex;
     align-items: center;
 
     &:hover,
     &:focus {
-        background: $ez-ground-base-medium-hover;
+        background: $ez-ground-base-dark-hover;
         outline: none;
     }
 
@@ -22,6 +23,7 @@
     &--selected:focus {
         background: $ez-ground-base-dark;
         color: $ez-black;
+        fill: $ez-black;
         font-weight: bold;
     }
 


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-30021

Fixes styling of:
- tabs
- content table header font (should be bold) (Bookmarks, Search)
- ~content table fine grey lines (see comment)~ (Fix moved to other PR: https://github.com/ezsystems/ezplatform-admin-ui-modules/pull/135)

Tabs:
![screen shot 2019-01-23 at 11 54 16](https://user-images.githubusercontent.com/10233057/51607027-d632bd80-1f13-11e9-9645-0c07b75ffd2c.png)
![screen shot 2019-01-23 at 11 54 25](https://user-images.githubusercontent.com/10233057/51601981-15f2a880-1f06-11e9-89ef-9238d115d21c.png)
