### PR TITLE
EZP-30232: Item highlight is cropped in Content Tree with scroll

### DIFF
--- a/Resources/public/scss/modules/content-tree/_list.scss
+++ b/Resources/public/scss/modules/content-tree/_list.scss
@@ -3,3 +3,10 @@
     padding: 0 0 0 calculateRem(12px);
     list-style: none;
 }
+
+.m-tree__scrollable-wrapper {
+    > .c-list {
+        display: table;
+        width: 100%;
+    }
+}


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-30232

### Before
![screen shot 2019-03-06 at 09 58 48](https://user-images.githubusercontent.com/10233057/53879152-0a6ac500-400e-11e9-97d3-de2f4f7dac90.png)

### After
![screen shot 2019-03-06 at 12 48 52](https://user-images.githubusercontent.com/10233057/53879231-3ab26380-400e-11e9-9685-631f88cbd908.png)

