### PR TITLE
EZP-30867: Setting priority of sub-items isn't reflected in ordering of the Content Tree

### DIFF
--- a/src/modules/sub-items/sub.items.module.js
+++ b/src/modules/sub-items/sub.items.module.js
@@ -322,6 +322,7 @@ export default class SubItemsModule extends Component {
     afterPriorityUpdated(response) {
         if (this.state.sortClause === 'LocationPriority') {
             this.discardActivePageItems();
+            this.refreshContentTree();
             return;
         }
 


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-30867

Excerpt from the ticket:
>Every time the user changes the priority of the content, the sub-items list is refreshed (unlike the Content Tree).