### PR TITLE
EZP-31038: As an editor, I want to perform more bulk actions on sub-items

### DIFF
--- a/Resources/public/scss/modules/sub-items-list/_action.btn.scss
+++ b/Resources/public/scss/modules/sub-items-list/_action.btn.scss
@@ -18,7 +18,10 @@
         opacity: 0.3;
     }
 
-    &--move {
+    &--move,
+    &--hide,
+    &--reveal,
+    &--create {
         border: calculateRem(1px) solid $ez-color-secondary;
         background: $ez-color-secondary;
 

--- a/Resources/public/scss/modules/sub-items-list/_action.btn.scss
+++ b/Resources/public/scss/modules/sub-items-list/_action.btn.scss
@@ -21,7 +21,7 @@
     &--move,
     &--hide,
     &--reveal,
-    &--create {
+    &--create-location {
         border: calculateRem(1px) solid $ez-color-secondary;
         background: $ez-color-secondary;
 

--- a/Resources/translations/sub_items.en.xliff
+++ b/Resources/translations/sub_items.en.xliff
@@ -98,7 +98,7 @@
       </trans-unit>
       <trans-unit id="5e5f346e9dca66d113585207c4e7a98e87421d34" resname="bulk_hide.error.message">
         <source>%failedCount% of the %totalCount% selected Location(s) could not be hidden because you do not have proper user permissions. {{ moreInformationLink }} Contact your Administrator to obtain permissions.</source>
-        <target state="new">%failedCount% of the %totalCount% selected location(s) could not be hidden because you do not have proper user permissions. {{ moreInformationLink }} Please contact your Administrator to obtain permissions.</target>
+        <target state="new">%failedCount% of the %totalCount% selected Location(s) could not be hidden because you do not have proper user permissions. {{ moreInformationLink }} Contact your Administrator to obtain permissions.</target>
         <note>key: bulk_hide.error.message</note>
       </trans-unit>
       <trans-unit id="9157594a9c2f44581165ee5e73c89bc5985a7fc9" resname="bulk_hide.success.message">

--- a/Resources/translations/sub_items.en.xliff
+++ b/Resources/translations/sub_items.en.xliff
@@ -36,15 +36,10 @@
         <target state="new">Content item(s) cannot be deleted or sent to trash (%itemsCount%)</target>
         <note>key: bulk_delete.error.modal.table_title.users_with_nonusers</note>
       </trans-unit>
-      <trans-unit id="c1ffafa700d4b0ba80a626363f9dfe853571e080" resname="bulk_delete.error.more_info">
-        <source><![CDATA[<u><a class='ez-notification-btn ez-notification-btn--show-modal'>Click here for more information.</a></u><br>]]></source>
-        <target state="new"><![CDATA[<u><a class='ez-notification-btn ez-notification-btn--show-modal'>Click here for more information.</a></u><br>]]></target>
-        <note>key: bulk_delete.error.more_info</note>
-      </trans-unit>
-      <trans-unit id="410f2ebb276d839b6606da042d0327a32e949093" resname="bulk_delete.popup.cancel">
+      <trans-unit id="aa8f660d8cae16394e7cd4421e6b604e031ad04b" resname="bulk_action.popup.cancel">
         <source>Cancel</source>
         <target state="new">Cancel</target>
-        <note>key: bulk_delete.popup.cancel</note>
+        <note>key: bulk_action.popup.cancel</note>
       </trans-unit>
       <trans-unit id="530f5b1097af7206fdabc3a51ac334c933ab4909" resname="bulk_delete.popup.confirm.nonusers">
         <source>Send to trash</source>
@@ -86,6 +81,71 @@
         <target state="new">The selected content item(s) have been sent to trash and the selected user(s) have been deleted.</target>
         <note>key: bulk_delete.success.message.users_with_nonusers</note>
       </trans-unit>
+      <trans-unit id="540d45bd030bab3e5bec8b9c1433ff4d9998c73e" resname="bulk_hide.popup.confirm">
+        <source>Hide</source>
+        <target state="new">Hide</target>
+        <note>key: bulk_hide.popup.confirm</note>
+      </trans-unit>
+      <trans-unit id="d2ab57f08d00c6f0d714b26aa81a44c8a1867903" resname="bulk_hide.popup.message">
+        <source>Are you sure you want to hide the selected location(s)?</source>
+        <target state="new">Are you sure you want to hide the selected location(s)?</target>
+        <note>key: bulk_hide.popup.message</note>
+      </trans-unit>
+      <trans-unit id="3a8fe14b551e382f3f1f20f7aed2e5de9804f619" resname="bulk_hide.error.modal.table_title">
+        <source>Locations cannot be hidden (%itemsCount%)</source>
+        <target state="new">Locations cannot be hidden (%itemsCount%)</target>
+        <note>key: bulk_hide.error.modal.table_title</note>
+      </trans-unit>
+      <trans-unit id="5e5f346e9dca66d113585207c4e7a98e87421d34" resname="bulk_hide.error.message">
+        <source>%failedCount% of the %totalCount% selected location(s) could not be hidden because you do not have proper user permissions. {{ moreInformationLink }} Please contact your Administrator to obtain permissions.</source>
+        <target state="new">%failedCount% of the %totalCount% selected location(s) could not be hidden because you do not have proper user permissions. {{ moreInformationLink }} Please contact your Administrator to obtain permissions.</target>
+        <note>key: bulk_hide.error.message</note>
+      </trans-unit>
+      <trans-unit id="9157594a9c2f44581165ee5e73c89bc5985a7fc9" resname="bulk_hide.success.message">
+        <source>The selected location(s) have been hidden.</source>
+        <target state="new">The selected location(s) have been hidden.</target>
+        <note>key: bulk_hide.success.message</note>
+      </trans-unit>
+      <trans-unit id="16c240de3cfc07b8e56d008357706abefad3e3ae" resname="bulk_unhide.popup.confirm">
+        <source>Reveal</source>
+        <target state="new">Reveal</target>
+        <note>key: bulk_unhide.popup.confirm</note>
+      </trans-unit>
+      <trans-unit id="99b9c21ff0ed8b33521c0b8c07410f1f10e5f879" resname="bulk_unhide.popup.message">
+        <source>Are you sure you want to reveal the selected location(s)?</source>
+        <target state="new">Are you sure you want to reveal the selected location(s)?</target>
+        <note>key: bulk_unhide.popup.message</note>
+      </trans-unit>
+      <trans-unit id="02b906429a29023075754b4dd3bf437b80a25ce6" resname="bulk_unhide.error.modal.table_title">
+        <source>Locations cannot be revealed (%itemsCount%)</source>
+        <target state="new">Locations cannot be revealed (%itemsCount%)</target>
+        <note>key: bulk_unhide.error.modal.table_title</note>
+      </trans-unit>
+      <trans-unit id="1208ce7816f3fa2b489c6946068c415949cf4c64" resname="bulk_unhide.error.message">
+        <source>%failedCount% of the %totalCount% selected location(s) could not be revealed because you do not have proper user permissions. {{ moreInformationLink }} Please contact your Administrator to obtain permissions.</source>
+        <target state="new">%failedCount% of the %totalCount% selected location(s) could not be revealed because you do not have proper user permissions. {{ moreInformationLink }} Please contact your Administrator to obtain permissions.</target>
+        <note>key: bulk_unhide.error.message</note>
+      </trans-unit>
+      <trans-unit id="edb883dfd8dc46cc6d99b10e9e6fd7bc708f72db" resname="bulk_unhide.success.message">
+        <source>The selected location(s) have been revealed.</source>
+        <target state="new">The selected location(s) have been revealed.</target>
+        <note>key: bulk_unhide.success.message</note>
+      </trans-unit>
+      <trans-unit id="d90e512d5cfd6d471246fad1cea365751b1cace5" resname="bulk_add_location.error.modal.table_title">
+        <source>Locations cannot be added (%itemsCount%)</source>
+        <target state="new">Locations cannot be added (%itemsCount%)</target>
+        <note>key: bulk_add_location.error.modal.table_title</note>
+      </trans-unit>
+      <trans-unit id="ba6155333e2bbe9f762d1e1462a9c3075ce38a75" resname="bulk_add_location.error.message">
+        <source>%failedCount% of the %totalCount% selected locations(s) could not be added because you do not have proper user permissions. {{ moreInformationLink }} Please contact your Administrator to obtain permissions.</source>
+        <target state="new">%failedCount% of the %totalCount% selected locations(s) could not be added because you do not have proper user permissions. {{ moreInformationLink }} Please contact your Administrator to obtain permissions.</target>
+        <note>key: bulk_add_location.error.message</note>
+      </trans-unit>
+      <trans-unit id="674c6872a8bb0ee30b38cc338bf6482dd78dde56" resname="bulk_add_location.success.message">
+        <source>The selected location(s) have been added to {{ locationLink }}.</source>
+        <target state="new">The selected location(s) have been added to {{ locationLink }}.</target>
+        <note>key: bulk_add_location.success.message</note>
+      </trans-unit>
       <trans-unit id="364a3498e021163497d9110380736b876beb326f" resname="bulk_move.error.message">
         <source>%notMovedCount% of the %totalCount% selected item(s) could not be moved because you do not have proper user permissions. {{ moreInformationLink }} Please contact your Administrator to obtain permissions.</source>
         <target state="new">%notMovedCount% of the %totalCount% selected item(s) could not be moved because you do not have proper user permissions. {{ moreInformationLink }} Please contact your Administrator to obtain permissions.</target>
@@ -96,15 +156,15 @@
         <target state="new">Content items cannot be moved (%itemsCount%)</target>
         <note>key: bulk_move.error.modal.table_title</note>
       </trans-unit>
-      <trans-unit id="704ee7a643332c4112613751caaf764496b8c5ac" resname="bulk_move.error.more_info">
+      <trans-unit id="ca61c6a680354ca0ca27b53f63d9d30ba35eee2a" resname="bulk_action.error.more_info">
         <source><![CDATA[<u><a class='ez-notification-btn ez-notification-btn--show-modal'>Click here for more information.</a></u><br>]]></source>
         <target state="new"><![CDATA[<u><a class='ez-notification-btn ez-notification-btn--show-modal'>Click here for more information.</a></u><br>]]></target>
-        <note>key: bulk_move.error.more_info</note>
+        <note>key: bulk_action.error.more_info</note>
       </trans-unit>
-      <trans-unit id="a1944f6944ef07fd9c744119c970b32ad6085954" resname="bulk_move.success.link_to_location">
+      <trans-unit id="98f3fdd964db64fa9cf168abd74cac45094cab72" resname="bulk_action.success.link_to_location">
         <source><![CDATA[<u><a href='%locationHref%'>%locationName%</a></u>]]></source>
         <target state="new"><![CDATA[<u><a href='%locationHref%'>%locationName%</a></u>]]></target>
-        <note>key: bulk_move.success.link_to_location</note>
+        <note>key: bulk_action.success.link_to_location</note>
       </trans-unit>
       <trans-unit id="ac326404ff958f8e3fa903df5750024602b812de" resname="bulk_move.success.message">
         <source>The selected content item(s) have been sent to {{ locationLink }}</source>
@@ -112,8 +172,8 @@
         <note>key: bulk_move.success.message</note>
       </trans-unit>
       <trans-unit id="93850319ec8e493cc4d0b8bb1ae2a87cdf26d3d6" resname="bulk_request.error.message">
-        <source>An unexpected error occurred while deleting the content item(s). Please try again later.</source>
-        <target state="new">An unexpected error occurred while deleting the content item(s). Please try again later.</target>
+        <source>An unexpected error occurred while processing the content item(s). Please try again later.</source>
+        <target state="new">An unexpected error occurred while processing the content item(s). Please try again later.</target>
         <note>key: bulk_request.error.message</note>
       </trans-unit>
       <trans-unit id="5e1792d4a193550fe8afd9a4be6d0a8c3f6596e9" resname="edit_item_btn.label">
@@ -210,6 +270,21 @@
         <source>Move selected items</source>
         <target state="new">Move selected items</target>
         <note>key: move_btn.label</note>
+      </trans-unit>
+      <trans-unit id="8d9e2f3fb15679717338a9f8ba95640c4b6b2e66" resname="add_locations_btn.label">
+        <source>Add locations for selected items</source>
+        <target state="new">Add locations for selected items</target>
+        <note>key: add_locations_btn.label</note>
+      </trans-unit>
+      <trans-unit id="0f2106150fc552b94658eee2125a4c4680f3564c" resname="hide_locations_btn.label">
+        <source>Hide selected locations</source>
+        <target state="new">Hide selected locations</target>
+        <note>key: hide_locations_btn.label</note>
+      </trans-unit>
+      <trans-unit id="8518fc267b3ab3f637351ddbd8ad08e1312d822c" resname="unhide_locations_btn.label">
+        <source>Reveal selected locations</source>
+        <target state="new">Reveal selected locations</target>
+        <note>key: unhide_locations_btn.label</note>
       </trans-unit>
       <trans-unit id="276a7024903672cd0476c82ba8845453e13db95e" resname="no_items.message">
         <source>This location has no sub-items</source>

--- a/Resources/translations/sub_items.en.xliff
+++ b/Resources/translations/sub_items.en.xliff
@@ -87,23 +87,23 @@
         <note>key: bulk_hide.popup.confirm</note>
       </trans-unit>
       <trans-unit id="d2ab57f08d00c6f0d714b26aa81a44c8a1867903" resname="bulk_hide.popup.message">
-        <source>Are you sure you want to hide the selected location(s)?</source>
-        <target state="new">Are you sure you want to hide the selected location(s)?</target>
+        <source>Are you sure you want to hide the selected Location(s)?</source>
+        <target state="new">Are you sure you want to hide the selected Location(s)?</target>
         <note>key: bulk_hide.popup.message</note>
       </trans-unit>
       <trans-unit id="3a8fe14b551e382f3f1f20f7aed2e5de9804f619" resname="bulk_hide.error.modal.table_title">
-        <source>Locations cannot be hidden (%itemsCount%)</source>
-        <target state="new">Locations cannot be hidden (%itemsCount%)</target>
+        <source>%itemsCount% Location(s) cannot be hidden</source>
+        <target state="new">%itemsCount% Location(s) cannot be hidden</target>
         <note>key: bulk_hide.error.modal.table_title</note>
       </trans-unit>
       <trans-unit id="5e5f346e9dca66d113585207c4e7a98e87421d34" resname="bulk_hide.error.message">
-        <source>%failedCount% of the %totalCount% selected location(s) could not be hidden because you do not have proper user permissions. {{ moreInformationLink }} Please contact your Administrator to obtain permissions.</source>
+        <source>%failedCount% of the %totalCount% selected Location(s) could not be hidden because you do not have proper user permissions. {{ moreInformationLink }} Contact your Administrator to obtain permissions.</source>
         <target state="new">%failedCount% of the %totalCount% selected location(s) could not be hidden because you do not have proper user permissions. {{ moreInformationLink }} Please contact your Administrator to obtain permissions.</target>
         <note>key: bulk_hide.error.message</note>
       </trans-unit>
       <trans-unit id="9157594a9c2f44581165ee5e73c89bc5985a7fc9" resname="bulk_hide.success.message">
-        <source>The selected location(s) have been hidden.</source>
-        <target state="new">The selected location(s) have been hidden.</target>
+        <source>Location(s) hidden.</source>
+        <target state="new">Location(s) hidden.</target>
         <note>key: bulk_hide.success.message</note>
       </trans-unit>
       <trans-unit id="16c240de3cfc07b8e56d008357706abefad3e3ae" resname="bulk_unhide.popup.confirm">
@@ -112,38 +112,38 @@
         <note>key: bulk_unhide.popup.confirm</note>
       </trans-unit>
       <trans-unit id="99b9c21ff0ed8b33521c0b8c07410f1f10e5f879" resname="bulk_unhide.popup.message">
-        <source>Are you sure you want to reveal the selected location(s)?</source>
-        <target state="new">Are you sure you want to reveal the selected location(s)?</target>
+        <source>Are you sure you want to reveal the selected Location(s)?</source>
+        <target state="new">Are you sure you want to reveal the selected Location(s)?</target>
         <note>key: bulk_unhide.popup.message</note>
       </trans-unit>
       <trans-unit id="02b906429a29023075754b4dd3bf437b80a25ce6" resname="bulk_unhide.error.modal.table_title">
-        <source>Locations cannot be revealed (%itemsCount%)</source>
-        <target state="new">Locations cannot be revealed (%itemsCount%)</target>
+        <source>%itemsCount% Location(s) cannot be revealed</source>
+        <target state="new">%itemsCount% Location(s) cannot be revealed</target>
         <note>key: bulk_unhide.error.modal.table_title</note>
       </trans-unit>
       <trans-unit id="1208ce7816f3fa2b489c6946068c415949cf4c64" resname="bulk_unhide.error.message">
-        <source>%failedCount% of the %totalCount% selected location(s) could not be revealed because you do not have proper user permissions. {{ moreInformationLink }} Please contact your Administrator to obtain permissions.</source>
-        <target state="new">%failedCount% of the %totalCount% selected location(s) could not be revealed because you do not have proper user permissions. {{ moreInformationLink }} Please contact your Administrator to obtain permissions.</target>
+        <source>%failedCount% of the %totalCount% selected Location(s) could not be revealed because you do not have proper user permissions. {{ moreInformationLink }} Contact your Administrator to obtain permissions.</source>
+        <target state="new">%failedCount% of the %totalCount% selected Location(s) could not be revealed because you do not have proper user permissions. {{ moreInformationLink }} Contact your Administrator to obtain permissions.</target>
         <note>key: bulk_unhide.error.message</note>
       </trans-unit>
       <trans-unit id="edb883dfd8dc46cc6d99b10e9e6fd7bc708f72db" resname="bulk_unhide.success.message">
-        <source>The selected location(s) have been revealed.</source>
-        <target state="new">The selected location(s) have been revealed.</target>
+        <source>Location(s) revealed.</source>
+        <target state="new">Location(s) revealed.</target>
         <note>key: bulk_unhide.success.message</note>
       </trans-unit>
       <trans-unit id="d90e512d5cfd6d471246fad1cea365751b1cace5" resname="bulk_add_location.error.modal.table_title">
-        <source>Locations cannot be added (%itemsCount%)</source>
-        <target state="new">Locations cannot be added (%itemsCount%)</target>
+        <source>%itemsCount% Location(s) cannot be added</source>
+        <target state="new">%itemsCount% Location(s) cannot be added</target>
         <note>key: bulk_add_location.error.modal.table_title</note>
       </trans-unit>
       <trans-unit id="ba6155333e2bbe9f762d1e1462a9c3075ce38a75" resname="bulk_add_location.error.message">
-        <source>%failedCount% of the %totalCount% selected locations(s) could not be added because you do not have proper user permissions. {{ moreInformationLink }} Please contact your Administrator to obtain permissions.</source>
-        <target state="new">%failedCount% of the %totalCount% selected locations(s) could not be added because you do not have proper user permissions. {{ moreInformationLink }} Please contact your Administrator to obtain permissions.</target>
+        <source>%failedCount% of the %totalCount% selected Locations(s) could not be added because you do not have proper user permissions. {{ moreInformationLink }} Contact your Administrator to obtain permissions.</source>
+        <target state="new">%failedCount% of the %totalCount% selected Locations(s) could not be added because you do not have proper user permissions. {{ moreInformationLink }} Contact your Administrator to obtain permissions.</target>
         <note>key: bulk_add_location.error.message</note>
       </trans-unit>
       <trans-unit id="674c6872a8bb0ee30b38cc338bf6482dd78dde56" resname="bulk_add_location.success.message">
-        <source>The selected location(s) have been added to {{ locationLink }}.</source>
-        <target state="new">The selected location(s) have been added to {{ locationLink }}.</target>
+        <source>Location(s) added to {{ locationLink }}.</source>
+        <target state="new">Location(s) added to {{ locationLink }}.</target>
         <note>key: bulk_add_location.success.message</note>
       </trans-unit>
       <trans-unit id="364a3498e021163497d9110380736b876beb326f" resname="bulk_move.error.message">
@@ -172,8 +172,8 @@
         <note>key: bulk_move.success.message</note>
       </trans-unit>
       <trans-unit id="93850319ec8e493cc4d0b8bb1ae2a87cdf26d3d6" resname="bulk_request.error.message">
-        <source>An unexpected error occurred while processing the content item(s). Please try again later.</source>
-        <target state="new">An unexpected error occurred while processing the content item(s). Please try again later.</target>
+        <source>An unexpected error occurred while processing the Content item(s). Please try again later.</source>
+        <target state="new">An unexpected error occurred while processing the Content item(s). Please try again later.</target>
         <note>key: bulk_request.error.message</note>
       </trans-unit>
       <trans-unit id="5e1792d4a193550fe8afd9a4be6d0a8c3f6596e9" resname="edit_item_btn.label">
@@ -272,18 +272,18 @@
         <note>key: move_btn.label</note>
       </trans-unit>
       <trans-unit id="8d9e2f3fb15679717338a9f8ba95640c4b6b2e66" resname="add_locations_btn.label">
-        <source>Add locations for selected items</source>
-        <target state="new">Add locations for selected items</target>
+        <source>Add Locations to selected Content item(s)</source>
+        <target state="new">Add Locations to selected Content item(s)</target>
         <note>key: add_locations_btn.label</note>
       </trans-unit>
       <trans-unit id="0f2106150fc552b94658eee2125a4c4680f3564c" resname="hide_locations_btn.label">
-        <source>Hide selected locations</source>
-        <target state="new">Hide selected locations</target>
+        <source>Hide selected Location(s)</source>
+        <target state="new">Hide selected Location(s)</target>
         <note>key: hide_locations_btn.label</note>
       </trans-unit>
       <trans-unit id="8518fc267b3ab3f637351ddbd8ad08e1312d822c" resname="unhide_locations_btn.label">
-        <source>Reveal selected locations</source>
-        <target state="new">Reveal selected locations</target>
+        <source>Reveal selected Location(s)</source>
+        <target state="new">Reveal selected Location(s)</target>
         <note>key: unhide_locations_btn.label</note>
       </trans-unit>
       <trans-unit id="276a7024903672cd0476c82ba8845453e13db95e" resname="no_items.message">

--- a/src/modules/sub-items/services/bulk.service.js
+++ b/src/modules/sub-items/services/bulk.service.js
@@ -155,7 +155,7 @@ const makeBulkRequest = ({ token, siteaccess }, requestBodyOperations, callback)
         .then(callback)
         .catch(() => {
             const message = Translator.trans(
-                /*@Desc("An unexpected error occurred while processing the content item(s). Please try again later.")*/
+                /*@Desc("An unexpected error occurred while processing the Content item(s). Please try again later.")*/
                 'bulk_request.error.message', {}, 'sub_items'
             );
 

--- a/src/modules/sub-items/services/endpoints.js
+++ b/src/modules/sub-items/services/endpoints.js
@@ -5,5 +5,6 @@ export const HEADERS_BULK = {
 export const TRASH_FAKE_LOCATION = '/api/ezp/v2/content/trash';
 export const USER_ENDPOINT = '/api/ezp/v2/user/users';
 export const LOCATION_ENDPOINT = '/api/ezp/v2/content/locations';
+export const CONTENT_OBJECTS_ENDPOINT = '/api/ezp/v2/content/objects';
 export const ENDPOINT_BULK = '/api/ezp/v2/bulk';
 export const ENDPOINT_GRAPHQL = '/graphql';

--- a/src/modules/sub-items/sub.items.module.js
+++ b/src/modules/sub-items/sub.items.module.js
@@ -357,7 +357,7 @@ export default class SubItemsModule extends Component {
 
         if (notMovedItems.length) {
             const modalTableTitle = Translator.trans(
-                /*@Desc("Content items cannot be moved (%itemsCount%)")*/
+                /*@Desc("%itemsCount% Content item(s) cannot be moved")*/
                 'bulk_move.error.modal.table_title', {itemsCount: notMovedItems.length}, 'sub_items'
             );
             const notificationMessage = Translator.trans(
@@ -380,7 +380,7 @@ export default class SubItemsModule extends Component {
 
         if (movedItems.length) {
             const message = Translator.trans(
-                /*@Desc("The selected content item(s) have been sent to {{ locationLink }}")*/
+                /*@Desc("Content item(s) sent to {{ locationLink }}")*/
                 'bulk_move.success.message', {}, 'sub_items'
             );
             const rawPlaceholdersMap = {
@@ -407,11 +407,11 @@ export default class SubItemsModule extends Component {
 
         if (failedItems.length) {
             const modalTableTitle = Translator.trans(
-                /*@Desc("Content items cannot be hidden (%itemsCount%)")*/
+                /*@Desc("%itemsCount% Content item(s) cannot be hidden")*/
                 'bulk_hide.error.modal.table_title', {itemsCount: failedItems.length}, 'sub_items'
             );
             const notificationMessage = Translator.trans(
-                /*@Desc("%failedCount% of the %totalCount% selected item(s) could not be hidden because you do not have proper user permissions. {{ moreInformationLink }} Please contact your Administrator to obtain permissions.")*/
+                /*@Desc("%failedCount% of the %totalCount% selected item(s) could not be hidden because you do not have proper user permissions. {{ moreInformationLink }} Contact your Administrator to obtain permissions.")*/
                 'bulk_hide.error.message',
                 {
                     failedCount: failedItems.length,
@@ -431,7 +431,7 @@ export default class SubItemsModule extends Component {
 
         if (successItems.length) {
             const message = Translator.trans(
-                /*@Desc("The selected location(s) have been hidden.")*/
+                /*@Desc("Location(s) hidden.")*/
                 'bulk_hide.success.message', {}, 'sub_items'
             );
             window.eZ.helpers.notification.showSuccessNotification(message);
@@ -445,11 +445,11 @@ export default class SubItemsModule extends Component {
 
         if (failedItems.length) {
             const modalTableTitle = Translator.trans(
-                /*@Desc("Locations cannot be revealed (%itemsCount%)")*/
+                /*@Desc("%itemsCount% Location(s) cannot be revealed")*/
                 'bulk_unhide.error.modal.table_title', {itemsCount: failedItems.length}, 'sub_items'
             );
             const notificationMessage = Translator.trans(
-                /*@Desc("%failedCount% of the %totalCount% selected location(s) could not be revealed because you do not have proper user permissions. {{ moreInformationLink }} Please contact your Administrator to obtain permissions.")*/
+                /*@Desc("%failedCount% of the %totalCount% selected Location(s) could not be revealed because you do not have proper user permissions. {{ moreInformationLink }} Contact your Administrator to obtain permissions.")*/
                 'bulk_unhide.error.message',
                 {
                     failedCount: failedItems.length,
@@ -484,11 +484,11 @@ export default class SubItemsModule extends Component {
 
         if (failedItems.length) {
             const modalTableTitle = Translator.trans(
-                /*@Desc("Locations cannot be added (%itemsCount%)")*/
+                /*@Desc("%itemsCount% Location(s) cannot be added")*/
                 'bulk_add_location.error.modal.table_title', {itemsCount: failedItems.length}, 'sub_items'
             );
             const notificationMessage = Translator.trans(
-                /*@Desc("%failedCount% of the %totalCount% selected locations(s) could not be added because you do not have proper user permissions. {{ moreInformationLink }} Please contact your Administrator to obtain permissions.")*/
+                /*@Desc("%failedCount% of the %totalCount% selected Locations(s) could not be added because you do not have proper user permissions. {{ moreInformationLink }} Contact your Administrator to obtain permissions.")*/
                 'bulk_add_location.error.message',
                 {
                     failedCount: failedItems.length,
@@ -508,7 +508,7 @@ export default class SubItemsModule extends Component {
 
         if (successItems.length) {
             const message = Translator.trans(
-                /*@Desc("The selected location(s) have been added to {{ locationLink }}")*/
+                /*@Desc("Location(s) added to {{ locationLink }}.")*/
                 'bulk_add_location.success.message', {}, 'sub_items'
             );
             const rawPlaceholdersMap = {
@@ -949,7 +949,7 @@ export default class SubItemsModule extends Component {
         }
 
         const confirmationMessage = Translator.trans(
-            /*@Desc("Are you sure you want to hide the selected location(s)?")*/
+            /*@Desc("Are you sure you want to hide the selected Location(s)?")*/
             'bulk_hide.popup.message', {}, 'sub_items'
         );
 
@@ -975,7 +975,7 @@ export default class SubItemsModule extends Component {
         }
 
         const confirmationMessage = Translator.trans(
-            /*@Desc("Are you sure you want to reveal the selected location(s)?")*/
+            /*@Desc("Are you sure you want to reveal the selected Location(s)?")*/
             'bulk_unhide.popup.message', {}, 'sub_items'
         );
 
@@ -1087,19 +1087,19 @@ export default class SubItemsModule extends Component {
     }
 
     renderBulkAddLocationBtn(disabled) {
-        const label = Translator.trans(/*@Desc("Add locations for selected items")*/ 'add_locations_btn.label', {}, 'sub_items');
+        const label = Translator.trans(/*@Desc("Add Locations to selected Content item(s)")*/ 'add_locations_btn.label', {}, 'sub_items');
 
         return <ActionButton disabled={disabled} onClick={this.onAddLocationsBtnClick} label={label} type="create" />;
     }
 
     renderBulkHideBtn(disabled) {
-        const label = Translator.trans(/*@Desc("Hide selected locations")*/ 'hide_locations_btn.label', {}, 'sub_items');
+        const label = Translator.trans(/*@Desc("Hide selected Locations")*/ 'hide_locations_btn.label', {}, 'sub_items');
 
         return <ActionButton disabled={disabled} onClick={this.onHideBtnClick} label={label} type="hide" />;
     }
 
     renderBulkUnhideBtn(disabled) {
-        const label = Translator.trans(/*@Desc("Reveal selected locations")*/ 'unhide_locations_btn.label', {}, 'sub_items');
+        const label = Translator.trans(/*@Desc("Reveal selected Locations")*/ 'unhide_locations_btn.label', {}, 'sub_items');
 
         return <ActionButton disabled={disabled} onClick={this.onUnhideBtnClick} label={label} type="reveal" />;
     }

--- a/src/modules/sub-items/sub.items.module.js
+++ b/src/modules/sub-items/sub.items.module.js
@@ -402,7 +402,6 @@ export default class SubItemsModule extends Component {
     afterBulkHide(successItems, failedItems) {
         this.deselectAllItems();
         this.discardActivePageItems();
-
         this.toggleBulkOperationStatusState(false);
 
         if (failedItems.length) {
@@ -434,6 +433,7 @@ export default class SubItemsModule extends Component {
                 /*@Desc("Location(s) hidden.")*/
                 'bulk_hide.success.message', {}, 'sub_items'
             );
+
             window.eZ.helpers.notification.showSuccessNotification(message);
         }
     }

--- a/src/modules/sub-items/sub.items.module.js
+++ b/src/modules/sub-items/sub.items.module.js
@@ -441,7 +441,6 @@ export default class SubItemsModule extends Component {
     afterBulkUnhide(successItems, failedItems) {
         this.deselectAllItems();
         this.discardActivePageItems();
-
         this.toggleBulkOperationStatusState(false);
 
         if (failedItems.length) {
@@ -473,6 +472,7 @@ export default class SubItemsModule extends Component {
                 /*@Desc("The selected location(s) have been revealed.")*/
                 'bulk_unhide.success.message', {}, 'sub_items'
             );
+
             window.eZ.helpers.notification.showSuccessNotification(message);
         }
     }
@@ -480,7 +480,6 @@ export default class SubItemsModule extends Component {
     afterBulkAddLocation(location, successItems, failedItems) {
         this.deselectAllItems();
         this.discardActivePageItems();
-
         this.toggleBulkOperationStatusState(false);
 
         if (failedItems.length) {
@@ -541,6 +540,7 @@ export default class SubItemsModule extends Component {
     onUdwConfirm([selectedLocation]) {
         this.closeUdw();
         const { actionFlow } = this.state;
+
         if (actionFlow === ACTION_FLOW_MOVE) {
             this.bulkMove(selectedLocation);
         } else {
@@ -943,6 +943,7 @@ export default class SubItemsModule extends Component {
 
     renderHideConfirmationPopup() {
         const { isBulkHidePopupVisible } = this.state;
+
         if (!isBulkHidePopupVisible) {
             return null;
         }
@@ -968,6 +969,7 @@ export default class SubItemsModule extends Component {
 
     renderUnhideConfirmationPopup() {
         const { isBulkUnhidePopupVisible } = this.state;
+
         if (!isBulkUnhidePopupVisible) {
             return null;
         }
@@ -1176,7 +1178,6 @@ export default class SubItemsModule extends Component {
         const bulkBtnDisabled = nothingSelected || !isTableViewActive || !pageLoaded;
         let bulkHideBtnDisabled = true;
         let bulkUnhideBtnDisabled = true;
-
         let listClassName = 'm-sub-items__list';
 
         if (isDuringBulkOperation) {
@@ -1185,6 +1186,7 @@ export default class SubItemsModule extends Component {
 
         if (!bulkBtnDisabled) {
             const selectedItemsValues = [...selectedItems.values()];
+
             bulkHideBtnDisabled = !selectedItemsValues.some(item => !item.hidden);
             bulkUnhideBtnDisabled = !selectedItemsValues.some(item => !!item.hidden);
         }

--- a/src/modules/sub-items/sub.items.module.js
+++ b/src/modules/sub-items/sub.items.module.js
@@ -549,18 +549,19 @@ export default class SubItemsModule extends Component {
     }
 
     renderUdw() {
-        const { isUdwOpened } = this.state;
+        const { isUdwOpened, actionFlow } = this.state;
 
         if (!isUdwOpened) {
             return null;
         }
 
         const UniversalDiscovery = window.eZ.modules.UniversalDiscovery;
-        const { restInfo, parentLocationId, udwConfigBulkItems } = this.props;
+        const { restInfo, parentLocationId, udwConfigBulkMoveItems, udwConfigBulkAddLocation } = this.props;
         const { selectedItems } = this.state;
         const selectedItemsLocationsIds = [...selectedItems.values()].map(({ id }) => id);
         const excludedLocations = [parentLocationId, ...selectedItemsLocationsIds];
         const title = Translator.trans(/*@Desc("Choose location")*/ 'udw.choose_location.title', {}, 'sub_items');
+        const udwConfig = actionFlow === ACTION_FLOW_MOVE ? udwConfigBulkMoveItems : udwConfigBulkAddLocation;
         const udwProps = {
             title,
             restInfo,
@@ -569,8 +570,7 @@ export default class SubItemsModule extends Component {
             canSelectContent: ({ item }, callback) => {
                 callback(!excludedLocations.includes(item.id));
             },
-            ...udwConfigBulkItems,
-            multiple: false,
+            ...udwConfig,
         };
 
         return ReactDOM.createPortal(<UniversalDiscovery {...udwProps} />, this.udwContainer);
@@ -1248,7 +1248,8 @@ SubItemsModule.propTypes = {
     generateLink: PropTypes.func.isRequired,
     totalCount: PropTypes.number,
     languages: PropTypes.object,
-    udwConfigBulkItems: PropTypes.object.isRequired,
+    udwConfigBulkMoveItems: PropTypes.object.isRequired,
+    udwConfigBulkAddLocation: PropTypes.object.isRequired,
     showBulkActionFailedModal: PropTypes.func.isRequired,
 };
 

--- a/src/modules/sub-items/sub.items.module.js
+++ b/src/modules/sub-items/sub.items.module.js
@@ -1089,7 +1089,7 @@ export default class SubItemsModule extends Component {
     renderBulkAddLocationBtn(disabled) {
         const label = Translator.trans(/*@Desc("Add Locations to selected Content item(s)")*/ 'add_locations_btn.label', {}, 'sub_items');
 
-        return <ActionButton disabled={disabled} onClick={this.onAddLocationsBtnClick} label={label} type="create" />;
+        return <ActionButton disabled={disabled} onClick={this.onAddLocationsBtnClick} label={label} type="create-location" />;
     }
 
     renderBulkHideBtn(disabled) {

--- a/src/modules/sub-items/sub.items.module.js
+++ b/src/modules/sub-items/sub.items.module.js
@@ -981,7 +981,7 @@ export default class SubItemsModule extends Component {
 
         return ReactDOM.createPortal(
             <Popup
-                onClose={this.closeBulkHidePopup}
+                onClose={this.closeBulkUnhidePopup}
                 isVisible={isBulkUnhidePopupVisible}
                 isLoading={false}
                 size="medium"


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31038](https://jira.ez.no/browse/EZP-31038)
| **Type**           |  Feature
| **Target version** | `master`
| **BC breaks**      | no
| **Doc needed**     | no

New bulk actions implemented: "Hide Locations", "Unhide Locations", "Add Locations"

Notes:
- after this PR merged, changes in [ezsystems/ezplatform-i18n : ezplatform-admin-ui-modules/sub_items.xlf](https://github.com/ezsystems/ezplatform-i18n/blob/master/ezplatform-admin-ui-modules/sub_items.xlf) required.
- During implementation, I found 2 years old bug (and this PR inherited the same). I believe it should be addressed outside of this PR. Separate Jira issue created for it [EZP-31039](https://jira.ez.no/browse/EZP-31039)
- require these changes: https://github.com/ezsystems/ezplatform-admin-ui/pull/1108