### PR TITLE
EZP-30159: Content can't be created in the preconfigured location using UDW.

### DIFF
--- a/src/modules/universal-discovery/components/tab-content/create.panel.component.js
+++ b/src/modules/universal-discovery/components/tab-content/create.panel.component.js
@@ -9,7 +9,7 @@ const CreatePanelComponent = (props) => {
     const wrapperAttrs = { className: 'c-create-panel' };
     const maxHeight = props.maxHeight - 24;
     const componentProps = { ...props, maxHeight, allowContainersOnly: true };
-    const finderProps = { ...componentProps, multiple: false };
+    const finderProps = { ...componentProps, multiple: false, renderStartingLocation: true };
     const chooseLanguageAndContentTypeTitle = Translator.trans(
         /*@Desc("Choose Language and Content Type")*/ 'content_on_the_fly.choose_language_and_content_type.title',
         {},


### PR DESCRIPTION
**Jira ticket:** https://jira.ez.no/browse/EZP-30159

Now the content on the fly (create tab) will render additional branch with the starting location except the root location with id:1 (because in the whole application there is no way to create content under the root location).

**Screen:**
![cotf-starting-location](https://user-images.githubusercontent.com/12594013/67208102-30b26900-f415-11e9-9b04-834894087fbd.png)
On the screen the starting location is set to `Images` folder