### PR TITLE
EZP-31260: Double clicking on the location without children disappears the preview in UDW

### DIFF
--- a/src/modules/universal-discovery/components/finder/finder.leaf.js
+++ b/src/modules/universal-discovery/components/finder/finder.leaf.js
@@ -29,8 +29,9 @@ const FinderLeaf = ({ location }) => {
         (containersOnly && !isContainer) || (allowedContentTypes && !allowedContentTypes.includes(contentTypeInfo.identifier));
     const markLocation = ({ nativeEvent }) => {
         const isSelectionButtonClicked = nativeEvent.target.closest('.c-toggle-selection-button');
+        const isMarkedLocationClicked = location.id === markedLocation;
 
-        if (isSelectionButtonClicked) {
+        if (isSelectionButtonClicked || isMarkedLocationClicked) {
             return;
         }
 


### PR DESCRIPTION
**Jira ticket:** https://jira.ez.no/browse/EZP-31260