### PR TITLE
EZP-31367: Content tree should display the root location of the section

### DIFF
--- a/Resources/public/scss/modules/content-tree/_list.item.scss
+++ b/Resources/public/scss/modules/content-tree/_list.item.scss
@@ -116,12 +116,6 @@ $list-item-height: calculateRem(20px);
         overflow: hidden;
     }
 
-    &--is-root-item {
-        > .c-list {
-            padding-left: 0;
-        }
-    }
-
     &--has-sub-items {
         > #{$list-item}__label {
             #{$list-item}__toggler {

--- a/src/modules/content-tree/components/list-item/list.item.component.js
+++ b/src/modules/content-tree/components/list-item/list.item.component.js
@@ -94,14 +94,19 @@ class ListItem extends Component {
      * @returns {JSX.Element}
      */
     renderIcon() {
-        const { contentTypeIdentifier, selected } = this.props;
+        const { contentTypeIdentifier, selected, locationId } = this.props;
         const iconAttrs = {
             extraClasses: `ez-icon--small ez-icon--${selected ? 'light' : 'dark'}`,
         };
 
         if (!this.state.isLoading || this.props.subitems.length) {
-            iconAttrs.customPath =
-                eZ.helpers.contentType.getContentTypeIconUrl(contentTypeIdentifier) || eZ.helpers.contentType.getContentTypeIconUrl('file');
+            if (locationId === 1) {
+                iconAttrs.customPath = eZ.helpers.contentType.getContentTypeIconUrl('folder');
+            } else {
+                iconAttrs.customPath =
+                    eZ.helpers.contentType.getContentTypeIconUrl(contentTypeIdentifier) ||
+                    eZ.helpers.contentType.getContentTypeIconUrl('file');
+            }
         } else {
             iconAttrs.name = 'spinner';
             iconAttrs.extraClasses = `${iconAttrs.extraClasses} ez-spin`;
@@ -153,10 +158,6 @@ class ListItem extends Component {
     }
 
     renderItemLabel() {
-        if (this.props.isRootItem) {
-            return null;
-        }
-
         const { totalSubitemsCount, href, name, selected } = this.props;
         const togglerClassName = 'c-list-item__toggler';
         const togglerAttrs = {

--- a/src/modules/content-tree/components/list-item/list.item.component.js
+++ b/src/modules/content-tree/components/list-item/list.item.component.js
@@ -158,7 +158,12 @@ class ListItem extends Component {
     }
 
     renderItemLabel() {
-        const { totalSubitemsCount, href, name, selected } = this.props;
+        const { totalSubitemsCount, href, name, selected, locationId } = this.props;
+
+        if (locationId === 1) {
+            return null;
+        }
+
         const togglerClassName = 'c-list-item__toggler';
         const togglerAttrs = {
             className: togglerClassName,


### PR DESCRIPTION
**Jira ticket:** https://jira.ez.no/browse/EZP-31367
**Requires:** https://github.com/ezsystems/ezplatform-admin-ui/pull/1230

For QA: Please test also case when root location in content tree is set to locationId: 1