### PR TITLE
EZP-31310: Fixed VersionDraftConflict for content having multiple locations

### DIFF
--- a/src/modules/sub-items/components/table-view/table.view.item.component.js
+++ b/src/modules/sub-items/components/table-view/table.view.item.component.js
@@ -93,7 +93,7 @@ export default class TableViewItemComponent extends PureComponent {
      * @memberof TableViewItemComponent
      */
     handleEdit() {
-        this.props.handleEditItem(this.props.content);
+        this.props.handleEditItem(this.props.content, this.props.location);
     }
 
     setPriorityInputRef(ref) {


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-31310
| Bug fix?      | yes
| New feature?  |no
| BC breaks?    |no
| Tests pass?   | yes/no
| Doc needed?   | yes/no
| Related to | https://github.com/ezsystems/ezplatform-admin-ui/pull/1237
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


When the user wants to edit the content that has multiple locations and occurs checking if unpublished draft exists then we need to know in which location the user tries to do this. This is needed to prepare proper links to edit versions. We should do this when it is possible (when a user is on the location view). When the user wants to edit content from a dashboard then the location is unknown. Therefore ContentEditViewBuilder must not only check the main Location but also other possible locations to which a user may have access. 


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review
