### PR TITLE
[Travis] Updated to Focal

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: trusty
+dist: focal
 language: php
 php:
   - 7.1
@@ -40,13 +40,13 @@ install:
   - ./.travis/prepare_ezplatform.sh
 
 script:
-  - cd "$HOME/build/ezplatform"; docker-compose exec --user www-data app sh -c "./bin/ezbehat $BEHAT_OPTS"
+  - cd "$HOME/build/ezplatform"; docker-compose --env-file=.env exec --user www-data app sh -c "./bin/ezbehat $BEHAT_OPTS"
 
 after_failure:
   # Will show us the last bit of the log of container's main processes
   # (not counting shell process above running php and behat)
   # NOTE: errors during docker setup of travis build won't show up here (can't output all as it is too much in debug/verbose mode)
-  - docker-compose logs -t --tail=15
+  - docker-compose --env-file=.env logs -t --tail=15
   # Will show us what is up, and how long it's been up
   - docker ps -s
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: focal
+dist: trusty
 language: php
 php:
   - 7.1
@@ -15,7 +15,7 @@ cache:
   directories:
     - $HOME/.composer/cache
 
-# test only master and stable branches (+ Pull requests)
+#A test only master and stable branches (+ Pull requests)
 branches:
     only:
         - master
@@ -30,24 +30,26 @@ notifications:
     on_pull_requests: false
 
 install:
-  # Disable XDebug for performance
+  #A Disable XDebug for performance
   - phpenv config-rm xdebug.ini
-  # Get latest composer build
+  #A Disable expired certificate
+  - sed -i '/mozilla\/DST_Root_CA_X3.crt/ s/./!&/' /etc/ca-certificates.conf \ && update-ca-certificates --verbose
+  #A Get latest composer build
   - travis_retry composer selfupdate
-  # Avoid memory issues on composer install
+  #A Avoid memory issues on composer install
   - echo "memory_limit=-1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
-  # Prepare Behat environment
+  #A Prepare Behat environment
   - ./.travis/prepare_ezplatform.sh
 
 script:
-  - cd "$HOME/build/ezplatform"; docker-compose --env-file=.env exec --user www-data app sh -c "./bin/ezbehat $BEHAT_OPTS"
+  - cd "$HOME/build/ezplatform"; docker-compose exec --user www-data app sh -c "./bin/ezbehat $BEHAT_OPTS"
 
 after_failure:
-  # Will show us the last bit of the log of container's main processes
-  # (not counting shell process above running php and behat)
-  # NOTE: errors during docker setup of travis build won't show up here (can't output all as it is too much in debug/verbose mode)
-  - docker-compose --env-file=.env logs -t --tail=15
-  # Will show us what is up, and how long it's been up
+  #A Will show us the last bit of the log of container's main processes
+  #A (not counting shell process above running php and behat)
+  #A NOTE: errors during docker setup of travis build won't show up here (can't output all as it is too much in debug/verbose mode)
+  - docker-compose logs -t --tail=15
+  #A Will show us what is up, and how long it's been up
   - docker ps -s
 
 after_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ cache:
   directories:
     - $HOME/.composer/cache
 
-#A test only master and stable branches (+ Pull requests)
+# test only master and stable branches (+ Pull requests)
 branches:
     only:
         - master
@@ -30,26 +30,26 @@ notifications:
     on_pull_requests: false
 
 install:
-  #A Disable XDebug for performance
+  # Disable XDebug for performance
   - phpenv config-rm xdebug.ini
-  #A Disable expired certificate
+  # Disable expired certificate
   - sed -i '/mozilla\/DST_Root_CA_X3.crt/ s/./!&/' /etc/ca-certificates.conf \ && update-ca-certificates --verbose
-  #A Get latest composer build
+  # Get latest composer build
   - travis_retry composer selfupdate
-  #A Avoid memory issues on composer install
+  # Avoid memory issues on composer install
   - echo "memory_limit=-1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
-  #A Prepare Behat environment
+  # Prepare Behat environment
   - ./.travis/prepare_ezplatform.sh
 
 script:
   - cd "$HOME/build/ezplatform"; docker-compose exec --user www-data app sh -c "./bin/ezbehat $BEHAT_OPTS"
 
 after_failure:
-  #A Will show us the last bit of the log of container's main processes
-  #A (not counting shell process above running php and behat)
-  #A NOTE: errors during docker setup of travis build won't show up here (can't output all as it is too much in debug/verbose mode)
+  # Will show us the last bit of the log of container's main processes
+  # (not counting shell process above running php and behat)
+  # NOTE: errors during docker setup of travis build won't show up here (can't output all as it is too much in debug/verbose mode)
   - docker-compose logs -t --tail=15
-  #A Will show us what is up, and how long it's been up
+  # Will show us what is up, and how long it's been up
   - docker ps -s
 
 after_script:


### PR DESCRIPTION
This PR updates the dist used by Travis to Focal. 

It's related to https://github.com/ezsystems/docker-php/pull/61 - Trusty has OpenSSL 1.0.2, which means that it produces errors when accessing sites using Let's Encrypt certificates. Focal uses the bug-free version (1.1.1).

Focal also has a higher Docker Compose version (1.29.2), which had a change in behaviour compared to the one used on Trusty:
```
Compose supports declaring default environment variables in an environment file named .env placed in the project directory. Docker Compose versions earlier than 1.28, load the .env file from the current working directory, where the command is executed, or from the project directory if this is explicitly set with the --project-directory option. This inconsistency has been addressed starting with +v1.28 by limiting the default .env file path to the project directory. You can use the --env-file commandline option to override the default .env and specify the path to a custom environment file.

The project directory is specified by the order of precedence:

    --project-directory flag
    Folder of the first --file flag
    Current directory
```
[ref](https://docs.docker.com/compose/env-file/)

I'm adding `--env-file=.env` to every docker-compose call to account for that.